### PR TITLE
Remove require of AR.

### DIFF
--- a/lib/turnout/engine.rb
+++ b/lib/turnout/engine.rb
@@ -5,7 +5,7 @@ require 'rails' unless defined? Rails
 # For Rails 3
 if defined? Rails::Engine
 
-  require 'active_record'
+  #require 'active_record'
 
   module Turnout
     class Engine < Rails::Engine


### PR DESCRIPTION
Can't see a reason that the `require 'active_record'` line is there. Seems to work fine without it (no tests.)

In the case of alternate data stores (datamapper, mongoid, etc.) this line breaks the gem/the rails installation.
