### PR TITLE
fix "reason" for the multi-byte characters problem

### DIFF
--- a/lib/rack/turnout.rb
+++ b/lib/rack/turnout.rb
@@ -89,7 +89,7 @@ class Rack::Turnout
     
     if settings['reason']
       html = Nokogiri::HTML(content)
-      html.at_css('#reason').inner_html = settings['reason']
+      html.at_css('#reason').inner_html = Nokogiri::HTML.fragment(settings['reason'])
       content = html.to_s
     end
     


### PR DESCRIPTION
Nokogiri::XML::Node#inner_html= value will be parsed as a complete html before set.
At that time, multi-byte characters are garbled.

Nokogiri::XML.fragment is parse html as a partial.
