### PR TITLE
allow custom maintenance.yml directory

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,6 +96,8 @@ So if you want to get the maintenance page up or down in a hury `touch tmp/maint
 
 Turnout will attempt to parse the `maintenance.yml` file looking for `reason` and `allowed_ip` settings. The file is not cached so you can change these values manually or just rerun the `rake maintenance:start` command.
 
+The location of `maintenance.yml` can be configured using `Turnout.config.update dir: 'your_dir'`.  In Rails, you can drop this in `./config/initializers/turnout_config.rb`.  Using rake activation this would be passed as environment variable `dir`: `dir=tmp/maint rake maintenance:start`.
+
 Example maintenance.yml File
 ----------------------------
 

--- a/lib/rack/turnout.rb
+++ b/lib/rack/turnout.rb
@@ -70,7 +70,7 @@ class Rack::Turnout
   end
 
   def settings_file
-    Turnout.config.app_root.join('tmp', 'maintenance.yml')
+    Turnout.config.app_root.join(Turnout.config.dir, 'maintenance.yml')
   end
 
   def maintenance_file_exists?

--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -8,7 +8,9 @@ namespace :maintenance do
       'response_code' => ENV['response_code']
     }
 
-    Dir.mkdir 'tmp' unless Dir.exists? 'tmp'
+    Turnout.config.update dir: ENV['dir'] if ENV['dir'].present?
+
+    Dir.mkdir Turnout.config.dir unless Dir.exists? Turnout.config.dir
     file = File.open settings_file, 'w'
     file.write settings.to_yaml
     file.close
@@ -19,13 +21,15 @@ namespace :maintenance do
 
   desc 'Disable the maintenance mode page'
   task :end do
+    Turnout.config.update dir: ENV['dir'] if ENV['dir'].present?
+
     File.delete settings_file
 
     puts "Deleted #{settings_file}"
   end
 
   def settings_file
-    Rails.root.join('tmp', 'maintenance.yml')
+    Rails.root.join(Turnout.config.dir, 'maintenance.yml')
   end
 
   def split_paths(paths_string)

--- a/lib/turnout/configuration.rb
+++ b/lib/turnout/configuration.rb
@@ -1,6 +1,6 @@
 module Turnout
   class Configuration
-    SETTINGS = [:app_root]
+    SETTINGS = [:app_root, :dir]
 
     SETTINGS.each do |setting|
       attr_accessor setting
@@ -8,10 +8,15 @@ module Turnout
 
     def initialize
       @app_root = '.'
+      @dir = 'tmp'
     end
 
     def app_root
       Pathname.new(@app_root.to_s)
+    end
+
+    def dir
+      @dir
     end
 
     def update(settings_hash)

--- a/spec/turnout/configuration_spec.rb
+++ b/spec/turnout/configuration_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Turnout::Configuration do
   its(:app_root) { should be_a Pathname }
   its('app_root.to_s') { should eql '.' }
+  its(:dir) { should eq('tmp') }
 
   it { expect { subject.app_root = '/tmp' }.to change { subject.app_root }.from(Pathname.new('.')).to Pathname.new('/tmp') }
 
@@ -16,5 +17,11 @@ describe Turnout::Configuration do
       let(:settings) { {app_root: '/tmp'} }
       it { expect { subject.update(settings) }.to change { subject.app_root.to_s}.from('.').to '/tmp' }
     end
+
+    context 'maintenance dir' do
+      let(:settings) { {dir: 'tmp/main_dir'} }
+      it { expect { subject.update(settings) }.to change { subject.dir.to_s }.from('tmp').to 'tmp/main_dir' }
+    end
+
   end
 end


### PR DESCRIPTION
Adds support for a customer `maintenance.yml` directory.

During rake activation this is done via environment variable `dir`.  I'm a little worried this will run into collisions.  Thoughts?

Within Rails/Rack applications configuration is set via `Turnout.config.update dir: 'some/path'`.  This can be done in a Rails initializer.
