### PR TITLE
care for multibyte characters

### DIFF
--- a/lib/turnout/maintenance_page/base.rb
+++ b/lib/turnout/maintenance_page/base.rb
@@ -34,7 +34,7 @@ module Turnout
       end
 
       def length
-        content.size.to_s
+        content.bytesize.to_s
       end
 
       def body


### PR DESCRIPTION
The size method counts multibyte character as "1".
So as we use multibyte character, the tail of maintenance.html is trimmed.
![screen shot 2014-09-04 at 21 15 06](https://cloud.githubusercontent.com/assets/2055516/4148913/48bece74-342d-11e4-896b-70829e9a41f4.png)
