### PR TITLE
Make the default list of allowed paths configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Turnout can be configured in two different ways:
       named_maintenance_file_paths: {app: 'tmp/app.yml', server: '/tmp/server.yml'},
       default_maintenance_page: Turnout::MaintenancePage::JSON,
       default_reason: 'Somebody googled Google!',
+      default_allowed_paths: ['^/admin/'],
       default_response_code: 418,
       default_retry_after: 3600
     ```
@@ -113,6 +114,7 @@ Turnout can be configured in two different ways:
       config.named_maintenance_file_paths = {app: 'tmp/app.yml', server: '/tmp/server.yml'}
       config.default_maintenance_page = Turnout::MaintenancePage::JSON
       config.default_reason = 'Somebody googled Google!'
+      config.default_allowed_paths = ['^/admin/']
       config.default_response_code = 418
       config.default_retry_after = 3600
     end
@@ -129,6 +131,7 @@ Turnout.configure do |config|
   config.named_maintenance_file_paths = {default: config.app_root.join('tmp', 'maintenance.yml').to_s}
   config.default_maintenance_page = Turnout::MaintenancePage::HTML
   config.default_reason = "The site is temporarily down for maintenance.\nPlease check back soon."
+  config.default_allowed_paths = []
   config.default_response_code = 503
   config.default_retry_after = 7200
 end

--- a/lib/turnout/configuration.rb
+++ b/lib/turnout/configuration.rb
@@ -1,7 +1,7 @@
 module Turnout
   class Configuration
     SETTINGS = [:app_root, :named_maintenance_file_paths, :default_maintenance_page, :default_reason,
-                :default_response_code, :default_retry_after]
+                :default_allowed_paths, :default_response_code, :default_retry_after]
 
     SETTINGS.each do |setting|
       attr_accessor setting
@@ -12,6 +12,7 @@ module Turnout
       @named_maintenance_file_paths = {default: app_root.join('tmp', 'maintenance.yml').to_s}
       @default_maintenance_page = Turnout::MaintenancePage::HTML
       @default_reason = "The site is temporarily down for maintenance.\nPlease check back soon."
+      @default_allowed_paths = []
       @default_response_code = 503
       @default_retry_after = 7200 # 2 hours by default
     end

--- a/lib/turnout/maintenance_file.rb
+++ b/lib/turnout/maintenance_file.rb
@@ -11,7 +11,7 @@ module Turnout
     def initialize(path)
       @path = path
       @reason = Turnout.config.default_reason
-      @allowed_paths = []
+      @allowed_paths = Turnout.config.default_allowed_paths
       @allowed_ips = []
       @response_code = Turnout.config.default_response_code
       @retry_after = Turnout.config.default_retry_after

--- a/spec/turnout/configuration_spec.rb
+++ b/spec/turnout/configuration_spec.rb
@@ -32,6 +32,10 @@ describe Turnout::Configuration do
     its(:default_reason) { should eql "The site is temporarily down for maintenance.\nPlease check back soon." }
   end
 
+  describe '#default_allowed_paths' do
+    its(:default_allowed_paths) { should eql [] }
+  end
+
   describe '#default_response_code' do
     its(:default_response_code) { should eql 503}
   end


### PR DESCRIPTION
Let them be specified in the `Turnout.configure` block so they don't need to be passed to the rake task each time.