### PR TITLE
allow environment to be passed to the HTML page

### DIFF
--- a/lib/rack/turnout.rb
+++ b/lib/rack/turnout.rb
@@ -18,7 +18,7 @@ class Rack::Turnout
 
     if settings && !request.allowed?(settings)
       page_class = Turnout::MaintenancePage.best_for(env)
-      page = page_class.new(settings.reason)
+      page = page_class.new(settings.reason, env)
 
       page.rack_response(settings.response_code, settings.retry_after)
     else

--- a/lib/rack/turnout.rb
+++ b/lib/rack/turnout.rb
@@ -18,7 +18,7 @@ class Rack::Turnout
 
     if settings && !request.allowed?(settings)
       page_class = Turnout::MaintenancePage.best_for(env)
-      page = page_class.new(settings.reason, env)
+      page = page_class.new(settings.reason, env: env)
 
       page.rack_response(settings.response_code, settings.retry_after)
     else

--- a/lib/turnout/maintenance_page.rb
+++ b/lib/turnout/maintenance_page.rb
@@ -12,8 +12,7 @@ module Turnout
 
       all_types = all.map(&:media_types).flatten
       best_type = request.best_media_type(all_types)
-      best = all.find { |page| page.media_types.include?(best_type) && File.exist?(page.new.path) }
-
+      best = all.find { |page| page.media_types.include?(best_type) && File.exist?(page.new.custom_path) }
       best || Turnout.config.default_maintenance_page
     end
 

--- a/lib/turnout/maintenance_page.rb
+++ b/lib/turnout/maintenance_page.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 module Turnout
   module MaintenancePage
     require 'rack/accept'
@@ -11,13 +12,13 @@ module Turnout
 
       all_types = all.map(&:media_types).flatten
       best_type = request.best_media_type(all_types)
-
-      best = all.find { |page| page.media_types.include? best_type }
+      best = all.find { |page| page.media_types.include?(best_type) && File.exist?(page.new.path) }
 
       best || Turnout.config.default_maintenance_page
     end
 
     require 'turnout/maintenance_page/base'
+    require 'turnout/maintenance_page/erb'
     require 'turnout/maintenance_page/html'
     require 'turnout/maintenance_page/json'
   end

--- a/lib/turnout/maintenance_page/base.rb
+++ b/lib/turnout/maintenance_page/base.rb
@@ -25,12 +25,8 @@ module Turnout
       end
       def extension() self.class.extension end
 
-      def path
-        if File.exists? custom_path
-          custom_path
-        else
-          default_path
-        end
+      def custom_path
+        Turnout.config.app_root.join('public', filename)
       end
 
       protected
@@ -62,13 +58,18 @@ module Turnout
         File.read(path)
       end
 
+      def path
+        if File.exists? custom_path
+          custom_path
+        else
+          default_path
+        end
+      end
+
       def default_path
         File.expand_path("../../../../public/#{filename}", __FILE__)
       end
 
-      def custom_path
-        Turnout.config.app_root.join('public', filename)
-      end
 
       def filename
         "maintenance.#{extension}"

--- a/lib/turnout/maintenance_page/base.rb
+++ b/lib/turnout/maintenance_page/base.rb
@@ -3,7 +3,8 @@ module Turnout
     class Base
       attr_reader :reason
 
-      def initialize(reason = nil)
+      def initialize(reason = nil, env = {})
+        @rack_env = env
         @reason = reason
       end
 

--- a/lib/turnout/maintenance_page/base.rb
+++ b/lib/turnout/maintenance_page/base.rb
@@ -25,6 +25,14 @@ module Turnout
       end
       def extension() self.class.extension end
 
+      def path
+        if File.exists? custom_path
+          custom_path
+        else
+          default_path
+        end
+      end
+
       protected
 
       def self.inherited(subclass)
@@ -47,15 +55,11 @@ module Turnout
       end
 
       def content
-        Tilt.new(path).render(nil, @options.reverse_merge(reason: reason))
+         file_content.gsub /{{\s?reason\s?}}/, reason
       end
 
-      def path
-        if File.exists? custom_path
-          custom_path
-        else
-          default_path
-        end
+      def file_content
+        File.read(path)
       end
 
       def default_path

--- a/lib/turnout/maintenance_page/base.rb
+++ b/lib/turnout/maintenance_page/base.rb
@@ -3,8 +3,8 @@ module Turnout
     class Base
       attr_reader :reason
 
-      def initialize(reason = nil, env = {})
-        @rack_env = env
+      def initialize(reason = nil, options = {})
+        @options = options.is_a?(Hash) ? options : {}
         @reason = reason
       end
 
@@ -47,11 +47,7 @@ module Turnout
       end
 
       def content
-        file_content.gsub /{{\s?reason\s?}}/, reason
-      end
-
-      def file_content
-        File.read(path)
+        Tilt.new(path).render(nil, @options.reverse_merge(reason: reason))
       end
 
       def path

--- a/lib/turnout/maintenance_page/erb.rb
+++ b/lib/turnout/maintenance_page/erb.rb
@@ -1,0 +1,18 @@
+require 'erb'
+require 'tilt'
+require 'tilt/erb'
+require_relative './html'
+module Turnout
+  module MaintenancePage
+    class Erb < Turnout::MaintenancePage::HTML
+
+      def content
+        Tilt.new(path).render(nil, {reason: reason}.merge(@options))
+      end
+
+      def self.extension
+        'html.erb'
+      end
+    end
+  end
+end

--- a/lib/turnout/maintenance_page/erb.rb
+++ b/lib/turnout/maintenance_page/erb.rb
@@ -7,7 +7,7 @@ module Turnout
     class Erb < Turnout::MaintenancePage::HTML
 
       def content
-        Tilt.new(path).render(nil, {reason: reason}.merge(@options))
+        Tilt.new(File.expand_path(path)).render(nil, {reason: reason}.merge(@options))
       end
 
       def self.extension

--- a/lib/turnout/maintenance_page/html.rb
+++ b/lib/turnout/maintenance_page/html.rb
@@ -1,3 +1,4 @@
+require_relative './base'
 module Turnout
   module MaintenancePage
     class HTML < Base

--- a/public/maintenance.html.erb
+++ b/public/maintenance.html.erb
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Down for Maintenance</title>
+
+    <style type="text/css">
+
+      *{
+        font-family: Arial, Helvetica, sans-serif;
+      }
+
+      body{
+        margin: 0;
+        background-color: #fff;
+      }
+
+      #page{
+        position: relative;
+        width: 550px;
+        margin: 200px auto;
+        padding: 75px 0;
+        text-align: center;
+        background-color: #eaeaea;
+        border: solid 1px #ccc;
+        border-top: solid 10px #666;
+        -moz-box-shadow: inset 0 2px 10px #ccc;
+        -webkit-box-shadow: inset 0 2px 10px #ccc;
+        box-shadow: inset 0 2px 10px #ccc;
+      }
+
+      header, #body{
+        width: 400px;
+        margin: 0 auto;
+      }
+
+      h1{
+        margin: 0;
+        color: #CC3601;
+        font-size: 26pt;
+        border-bottom: solid 4px #666;
+      }
+
+      #reason{
+        margin: 10px 0;
+        color: #333;
+      }
+
+    </style>
+
+  </head>
+  <body>
+
+    <section id="page">
+
+      <header>
+        <h1>Down for Maintenance</h1>
+      </header>
+
+      <section id="body">
+        <div>
+          <%= reason %>
+        </div>
+      </section>
+
+    </section>
+
+  </body>
+</html>

--- a/spec/turnout/maintenance_page/erb_spec.rb
+++ b/spec/turnout/maintenance_page/erb_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Turnout::MaintenancePage::Erb do
+  describe 'class methods' do
+
+    its(:media_types) { should eql %w{text/html application/xhtml+xml} }
+    its(:extension) { should eql 'html.erb' }
+  end
+
+  describe 'instance methods' do
+    let(:reason) { nil }
+    let(:instance) { Turnout::MaintenancePage::Erb.new(*[reason].compact) }
+    subject { instance }
+
+    describe '#reason' do
+      context 'without a reason' do
+        its(:reason) { should eql '' }
+      end
+
+      context 'with a reason' do
+        let(:reason) { "Just because.\nOkay!" }
+
+        its(:reason) { should eql "<p>Just because.</p>\n<p>Okay!</p>" }
+      end
+    end
+
+    describe '#rack_response' do
+      let(:reason) { 'Oops!' }
+      let(:code) { nil }
+      let(:retry_after) { nil }
+      let(:raw_response) { instance.rack_response(code, retry_after) }
+      subject { Rack::MockResponse.new(*raw_response) }
+
+      context 'without a code' do
+        it { expect(raw_response).to be_an Array }
+        its(:status) { should eql 503 }
+        its(:headers) { should be_a Hash }
+        its(:headers) { should have_key 'Content-Type' }
+        its(:headers) { should have_key 'Content-Length' }
+        its(:headers) { should_not have_key 'Retry-After' }
+        its(:content_type) { should eql 'text/html' }
+        its(:content_length) { should eql 1199 }
+        it { expect(raw_response[2]).to be_an Array }
+        its(:body) { should match '<html>' }
+        its(:body) { should match 'Oops!' }
+      end
+
+      context 'with a code' do
+        let(:code) { 418 }
+        its(:status) { should eql 418 }
+      end
+
+      context 'with retry_after' do
+        let(:retry_after) { 3600 }
+        its(:headers) { should include('Retry-After' => '3600')}
+      end
+    end
+  end
+end

--- a/spec/turnout/maintenance_page_spec.rb
+++ b/spec/turnout/maintenance_page_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Turnout::MaintenancePage do
   describe '.all' do
     its(:all) { should_not include Turnout::MaintenancePage::Base }
-    its(:all) { should eql [Turnout::MaintenancePage::HTML, Turnout::MaintenancePage::JSON] }
+    its(:all) { should eql [Turnout::MaintenancePage::HTML, Turnout::MaintenancePage::Erb, Turnout::MaintenancePage::JSON] }
   end
 
   describe '.best_for' do

--- a/turnout.gemspec
+++ b/turnout.gemspec
@@ -14,7 +14,7 @@ spec = Gem::Specification.new do |s|
   s.email = 'adam@codenoble.com'
   s.homepage = 'https://github.com/biola/turnout'
   s.license = 'MIT'
-  s.add_dependency('tilt', '~> 2.0')
+  s.add_dependency('tilt','>= 1.4', '< 3')
   s.add_dependency('rack', '~> 1.3')
   s.add_dependency('rack-accept', '~> 0.4')
   s.add_development_dependency('rack-test', '~> 0.6')

--- a/turnout.gemspec
+++ b/turnout.gemspec
@@ -14,6 +14,7 @@ spec = Gem::Specification.new do |s|
   s.email = 'adam@obledesign.com'
   s.homepage = 'https://github.com/biola/turnout'
   s.license = 'MIT'
+  s.add_dependency('tilt', '~> 2.0')
   s.add_dependency('rack', '~> 1.3')
   s.add_dependency('rack-accept', '~> 0.4')
   s.add_development_dependency('rack-test', '~> 0.6')


### PR DESCRIPTION
Hello, 
  I made few changes to allow the environment to be passed from the rack middleware to the HTML page. This is especially needed when you have other middlewares in your middleware stack that defines some variables in the environment that needed to be passed to the HTML page. 

Please let me know what you think. Thank you very much. 