### PR TITLE
fix default maintenance page when no best type found

### DIFF
--- a/lib/turnout/maintenance_page.rb
+++ b/lib/turnout/maintenance_page.rb
@@ -14,7 +14,7 @@ module Turnout
 
       best = all.find { |page| page.media_types.include? best_type }
 
-      best || Turnout.default_maintenance_page
+      best || Turnout.config.default_maintenance_page
     end
 
     require 'turnout/maintenance_page/base'

--- a/spec/turnout/maintenance_page_spec.rb
+++ b/spec/turnout/maintenance_page_spec.rb
@@ -27,5 +27,11 @@ describe Turnout::MaintenancePage do
 
       it { should eql Turnout::MaintenancePage::JSON }
     end
+
+    context 'with "image/gif" accept header' do
+      let(:content_type) { 'image/gif' }
+
+      it { should eql Turnout::MaintenancePage::HTML }
+    end
   end
 end


### PR DESCRIPTION
I noticed that a when adding certain media types to the accept headers that I would get a `undefined method `default_maintenance_page' for Turnout:Module`

I've added a small change and test covering the case I ran into.