### PR TITLE
Use self instead of nil when rendering pages with Tilt (erb support) 

### DIFF
--- a/lib/turnout/maintenance_page/erb.rb
+++ b/lib/turnout/maintenance_page/erb.rb
@@ -7,7 +7,7 @@ module Turnout
     class Erb < Turnout::MaintenancePage::HTML
 
       def content
-        Tilt.new(File.expand_path(path)).render(nil, {reason: reason}.merge(@options))
+        Tilt.new(File.expand_path(path)).render(self, {reason: reason}.merge(@options))
       end
 
       def self.extension


### PR DESCRIPTION
Hello, 
 I while back ago we worked on adding ERB support together. However i wanted to add I18n support for my application and i am currently using this middleware: 
```
require 'i18n'
require 'i18n/backend/fallbacks'
require 'sinatra/support'
require 'sinatra_more'
require 'sprockets'
require 'sinatra/asset_pipeline'

module Sinatra
  module I18n
    module Helpers
      def t(*args)
        ::I18n::t(*args)
      end
    end
  end
end


class I18nMiddleware

  def initialize(app)
    @app = app
  end

  def call(env)
    root = File.dirname(File.dirname(__FILE__))
    I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
    I18n.load_path = Dir[File.join(root, 'locales', '*.yml')]
    I18n.backend.load_translations
    I18n.enforce_available_locales = true
    @turnout_page = Turnout.config.default_maintenance_page
    @turnout_page.send(:include, Sinatra::I18n::Helpers)
    @turnout_page.send(:include, Sprockets::Helpers)
    @sinatra_base.send(:include, SinatraMore::TagHelpers)
    @app.call(env)
  end



end

```
However in order to work Tilt needs to know about the current class that is used ( Turnout::MaintenancePage::Erb ) in order to have access to the helpers included in the class.

This works perfectly for me. 

Let me know if you are ok whit this change. I could work on adding i18n support also to this gem if you think would be a nice idea. Of course would be a bit different though and with options to include custom helpers and to use the locale from browser. But wanted just to ask this question too.  