### PR TITLE
Added support for i18n  (ERB templates only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 *.gem
 Gemfile.lock
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
-nguage: ruby
+language: ruby
+sudo: false
+
+cache: bundler
+
+bundler_args: --no-deployment --binstubs=./bin
+
+before_install:
+  - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
+  - gem install bundler
+
+install:
+  - bundle install --path vendor/bundle
+
+script: bundle exec rspec
+
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.8
   - 2.2.4
   - 2.3.0
   - jruby-9.0.5.0
-script: bundle exec rspec
-before_install:
-  # fixes Travis CI error: NoMethodError: undefined method `spec' for nil:NilClass
-  - gem install bundler

--- a/lib/turnout/configuration.rb
+++ b/lib/turnout/configuration.rb
@@ -1,8 +1,9 @@
+require_relative './ordered_options'
 module Turnout
   class Configuration
     SETTINGS = [:app_root, :named_maintenance_file_paths,
       :maintenance_pages_path, :default_maintenance_page, :default_reason,
-      :default_allowed_paths, :default_response_code, :default_retry_after]
+      :default_allowed_paths, :default_response_code, :default_retry_after, :i18n]
 
     SETTINGS.each do |setting|
       attr_accessor setting
@@ -17,6 +18,12 @@ module Turnout
       @default_allowed_paths = []
       @default_response_code = 503
       @default_retry_after = 7200 # 2 hours by default
+      @i18n = Turnout::OrderedOptions.new
+      @i18n.railties_load_path = []
+      @i18n.load_path = []
+      @i18n.fallbacks = Turnout::OrderedOptions.new
+      @i18n.enabled = false
+      @i18n.use_language_header = false
     end
 
     def app_root

--- a/lib/turnout/i18n/accept_language_parser.rb
+++ b/lib/turnout/i18n/accept_language_parser.rb
@@ -1,0 +1,109 @@
+module Turnout
+  class AcceptLanguageParser
+    attr_accessor :header
+
+    def initialize(header)
+      @header = header
+    end
+
+    # Returns a sorted array based on user preference in HTTP_ACCEPT_LANGUAGE.
+    # Browsers send this HTTP header, so don't think this is holy.
+    #
+    # Example:
+    #
+    #   request.user_preferred_languages
+    #   # => [ 'nl-NL', 'nl-BE', 'nl', 'en-US', 'en' ]
+    #
+    def user_preferred_languages
+      return [] if header.to_s.strip.empty?
+      @user_preferred_languages ||= begin
+        header.to_s.gsub(/\s+/, '').split(',').map do |language|
+          locale, quality = language.split(';q=')
+          raise ArgumentError, 'Not correctly formatted' unless locale =~ /^[a-z\-0-9]+|\*$/i
+
+          locale  = locale.downcase.gsub(/-[a-z0-9]+$/i, &:upcase) # Uppercase territory
+          locale  = nil if locale == '*' # Ignore wildcards
+
+          quality = quality ? quality.to_f : 1.0
+
+          [locale, quality]
+        end.sort do |(_, left), (_, right)|
+          right <=> left
+        end.map(&:first).compact
+      rescue ArgumentError # Just rescue anything if the browser messed up badly.
+        []
+      end
+    end
+
+    # Sets the user languages preference, overriding the browser
+    #
+    def user_preferred_languages=(languages)
+      @user_preferred_languages = languages
+    end
+
+    # Finds the locale specifically requested by the browser.
+    #
+    # Example:
+    #
+    #   request.preferred_language_from I18n.available_locales
+    #   # => 'nl'
+    #
+    def preferred_language_from(array)
+      (user_preferred_languages & array.map(&:to_s)).first
+    end
+
+    # Returns the first of the user_preferred_languages that is compatible
+    # with the available locales. Ignores region.
+    #
+    # Example:
+    #
+    #   request.compatible_language_from I18n.available_locales
+    #
+    def compatible_language_from(available_languages)
+      user_preferred_languages.map do |preferred| #en-US
+        preferred = preferred.downcase
+        preferred_language = preferred.split('-', 2).first
+
+        available_languages.find do |available| # en
+          available = available.to_s.downcase
+          preferred == available || preferred_language == available.split('-', 2).first
+        end
+      end.compact.first
+    end
+
+    # Returns a supplied list of available locals without any extra application info
+    # that may be attached to the locale for storage in the application.
+    #
+    # Example:
+    # [ja_JP-x1, en-US-x4, en_UK-x5, fr-FR-x3] => [ja-JP, en-US, en-UK, fr-FR]
+    #
+    def sanitize_available_locales(available_languages)
+      available_languages.map do |available|
+        available.to_s.split(/[_-]/).reject { |part| part.start_with?("x") }.join("-")
+      end
+    end
+
+    # Returns the first of the user preferred languages that is
+    # also found in available languages.  Finds best fit by matching on
+    # primary language first and secondarily on region.  If no matching region is
+    # found, return the first language in the group matching that primary language.
+    #
+    # Example:
+    #
+    #   request.language_region_compatible(available_languages)
+    #
+    def language_region_compatible_from(available_languages)
+      available_languages = sanitize_available_locales(available_languages)
+      user_preferred_languages.map do |preferred| #en-US
+        preferred = preferred.downcase
+        preferred_language = preferred.split('-', 2).first
+
+        lang_group = available_languages.select do |available| # en
+          preferred_language == available.downcase.split('-', 2).first
+        end
+
+        lang_group.find { |lang| lang.downcase == preferred } || lang_group.first #en-US, en-UK
+      end.compact.first
+    end
+  end
+end

--- a/lib/turnout/i18n/internationalization.rb
+++ b/lib/turnout/i18n/internationalization.rb
@@ -1,0 +1,141 @@
+require 'i18n'
+require 'i18n/backend/fallbacks'
+require_relative './accept_language_parser'
+require_relative '../ordered_options'
+
+module Turnout
+  class Internationalization
+    class << self
+      attr_reader :env
+      attr_writer :env
+
+      def initialize_i18n(env)
+        @env = env
+        setup_i18n_config
+      end
+
+      def i18n_config
+        @i18n_config = Turnout.config.i18n
+        @i18n_config =  @i18n_config.is_a?(Turnout::OrderedOptions) ? @i18n_config : Turnout::InheritableOptions.new(@i18n_config)
+      end
+
+      def turnout_page
+        @turnout_page ||= Turnout.config.default_maintenance_page
+      end
+
+      def http_accept_language
+        language = (env.nil? || env.empty?) ? nil : env["HTTP_ACCEPT_LANGUAGE"]
+        @http_accept_language ||= Turnout::AcceptLanguageParser.new(language)
+      end
+
+      def setup_additional_helpers
+        i18n_additional_helpers = i18n_config.delete(:additional_helpers)
+        i18n_additional_helpers = i18n_additional_helpers.is_a?(Array) ? i18n_additional_helpers : []
+
+        i18n_additional_helpers.each do |helper|
+          turnout_page.send(:include, helper) if helper.is_a?(Module)
+        end
+      end
+
+      def expanded(path)
+        result = []
+        if File.directory?(path)
+          result.concat(Dir.glob(File.join(path, '**', '**')).map { |file| file }.sort)
+        else
+          result << path
+        end
+        result.uniq!
+        result
+      end
+
+      # Returns all expanded paths but only if they exist in the filesystem.
+      def existent(path)
+        expanded(path).select { |f| File.exist?(f) }
+      end
+
+      # Setup i18n configuration.
+      def setup_i18n_config
+        return unless i18n_config.enabled
+        setup_additional_helpers
+        fallbacks = i18n_config.delete(:fallbacks)
+
+
+        # Avoid issues with setting the default_locale by disabling available locales
+        # check while configuring.
+        enforce_available_locales = i18n_config.delete(:enforce_available_locales)
+        enforce_available_locales = I18n.enforce_available_locales if enforce_available_locales.nil?
+        I18n.enforce_available_locales = false
+
+        i18n_config.except(:enabled, :use_language_header).each do |setting, value|
+          case setting
+          when :railties_load_path
+            I18n.load_path.unshift(*value.map { |file| existent(file) }.flatten)
+          when :load_path
+            I18n.load_path += value
+          else
+            I18n.send("#{setting}=", value)
+          end
+        end
+
+
+        init_fallbacks(fallbacks) if fallbacks && validate_fallbacks(fallbacks)
+        I18n.backend.load_translations
+
+        # Restore available locales check so it will take place from now on.
+        I18n.enforce_available_locales = enforce_available_locales
+
+        begin
+          if i18n_config.use_language_header
+            I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales) || I18n.default_locale
+          else
+            I18n.locale = I18n.default_locale
+          end
+        rescue
+          #nothing
+        end
+
+      end
+
+      def array_wrap(object)
+        if object.nil?
+          []
+        elsif object.respond_to?(:to_ary)
+          object.to_ary || [object]
+        else
+          [object]
+        end
+      end
+
+      def include_fallbacks_module
+        I18n.backend.class.send(:include, I18n::Backend::Fallbacks)
+      end
+
+      def init_fallbacks(fallbacks)
+        include_fallbacks_module
+
+        args = case fallbacks
+        when Turnout::OrderedOptions
+          [*(fallbacks[:defaults] || []) << fallbacks[:map]].compact
+        when Hash, Array
+          array_wrap(fallbacks)
+        else # TrueClass
+          []
+        end
+
+        I18n.fallbacks = I18n::Locale::Fallbacks.new(*args)
+      end
+
+      def validate_fallbacks(fallbacks)
+        case fallbacks
+        when Turnout::OrderedOptions
+          !fallbacks.empty?
+        when TrueClass, Array, Hash
+          true
+        else
+          raise "Unexpected fallback type #{fallbacks.inspect}"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/turnout/maintenance_page/erb.rb
+++ b/lib/turnout/maintenance_page/erb.rb
@@ -2,17 +2,21 @@ require 'erb'
 require 'tilt'
 require 'tilt/erb'
 require_relative './html'
+require_relative '../i18n/internationalization'
+
 module Turnout
   module MaintenancePage
     class Erb < Turnout::MaintenancePage::HTML
 
       def content
+        Turnout::Internationalization.initialize_i18n(@options[:env])
         Tilt.new(File.expand_path(path)).render(self, {reason: reason}.merge(@options))
       end
-
+      
       def self.extension
         'html.erb'
       end
+
     end
   end
 end

--- a/lib/turnout/ordered_options.rb
+++ b/lib/turnout/ordered_options.rb
@@ -1,0 +1,98 @@
+module Turnout
+  class OrderedOptions < Hash
+    alias_method :_get, :[] # preserve the original #[] method
+    protected :_get # make it protected
+
+    def initialize(constructor = {}, &block)
+      if constructor.respond_to?(:to_hash)
+        super()
+        update(constructor, &block)
+        hash = constructor.to_hash
+
+        self.default = hash.default if hash.default
+        self.default_proc = hash.default_proc if hash.default_proc
+      else
+        super()
+      end
+    end
+
+    def update(other_hash)
+      if other_hash.is_a? Hash
+        super(other_hash)
+      else
+        other_hash.to_hash.each_pair do |key, value|
+          if block_given?
+            value = yield(key, value)
+          end
+          self[key] = value
+        end
+        self
+      end
+    end
+
+    def []=(key, value)
+      super(key.to_sym, value)
+    end
+
+    def [](key)
+      super(key.to_sym)
+    end
+
+    def method_missing(name, *args)
+      name_string = name.to_s
+      if name_string.chomp!('=')
+        self[name_string] = args.first
+      else
+        bangs = name_string.chomp!('!')
+
+        if bangs
+          value = fetch(name_string.to_sym)
+          raise(RuntimeError.new("#{name_string} is blank.")) if value.nil? || value.empty?
+          value
+        else
+          self[name_string]
+        end
+      end
+    end
+
+    def except(*keys)
+      dup.except!(*keys)
+    end
+
+    def except!(*keys)
+      keys.each { |key| delete(key) }
+      self
+    end
+
+
+    def respond_to_missing?(name, include_private)
+      true
+    end
+  end
+
+
+  # +InheritableOptions+ provides a constructor to build an +OrderedOptions+
+  # hash inherited from another hash.
+  #
+  # Use this if you already have some hash and you want to create a new one based on it.
+  #
+  #   h = ActiveSupport::InheritableOptions.new({ girl: 'Mary', boy: 'John' })
+  #   h.girl # => 'Mary'
+  #   h.boy  # => 'John'
+  class InheritableOptions < Turnout::OrderedOptions
+    def initialize(parent = nil)
+      if parent.kind_of?(Turnout::OrderedOptions)
+        # use the faster _get when dealing with OrderedOptions
+        super(parent) {|key,value| parent._get(key) }
+      elsif parent
+        super(parent) { |key, value| parent[key] }
+      else
+        super(parent)
+      end
+    end
+
+    def inheritable_copy
+      self.class.new(self)
+    end
+  end
+end

--- a/spec/locales/de.yml
+++ b/spec/locales/de.yml
@@ -1,0 +1,3 @@
+en:
+  global:
+    hello: "Hello World!"

--- a/spec/locales/en.yml
+++ b/spec/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  global:
+    hello: "Hello World!"
+
+    

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,25 @@
 require 'bundler/setup'
+require 'simplecov'
+require 'simplecov-summary'
+SimpleCov.start 'rails'
+ENV["RAILS_ENV"] ||= 'test'
 require 'rack/test'
 require 'rspec'
 require 'rspec/its'
 require 'rack/turnout'
 require 'fixtures/test_app'
+# require "codeclimate-test-reporter"
+formatters = [SimpleCov::Formatter::SummaryFormatter,SimpleCov::Formatter::HTMLFormatter]
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(formatters)
+
+SimpleCov.start :rails do
+  add_filter 'lib/tasks'
+  add_filter ['lib/turnout/version.rb', 'lib/turnout.rb', 'lib/turnout/rake_tasks.rb', 'lib/turnout/engine.rb']
+   at_exit do
+     SimpleCov.result.format!
+   end
+ end
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods

--- a/spec/turnout/i18n/accept_language_parser_spec.rb
+++ b/spec/turnout/i18n/accept_language_parser_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+describe Turnout::AcceptLanguageParser do
+    let(:languages) { 'en-us,en-gb;q=0.8,en;q=0.6,es-419' }
+
+    def parser
+      @parser ||= Turnout::AcceptLanguageParser.new(languages)
+    end
+
+    it 'sets user_prefered_language' do
+      parser.user_preferred_languages = languages
+      expect(parser.instance_variable_get("@user_preferred_languages")).to eq(languages)
+    end
+
+    it "should return empty array" do
+      parser.header = nil
+      expect(parser.user_preferred_languages).to eq []
+    end
+
+    it "should properly split" do
+      expect(parser.user_preferred_languages).to eq %w{en-US es-419 en-GB en}
+    end
+
+    it "should ignore jambled header" do
+      parser.header = 'odkhjf89fioma098jq .,.,'
+      expect(parser.user_preferred_languages).to eq []
+    end
+
+    it "should properly respect whitespace" do
+      parser.header = 'en-us, en-gb; q=0.8,en;q = 0.6,es-419'
+      expect(parser.user_preferred_languages).to eq %w{en-US es-419 en-GB en}
+    end
+
+    it "should find first available language" do
+      expect(parser.preferred_language_from(%w{en en-GB})).to eq "en-GB"
+    end
+
+    it "should find first compatible language" do
+      expect(parser.compatible_language_from(%w{en-hk})).to eq "en-hk"
+      expect(parser.compatible_language_from(%w{en})).to eq "en"
+    end
+
+    it "should find first compatible from user preferred" do
+      parser.header = 'en-us,de-de'
+      expect(parser.compatible_language_from(%w{de en})).to eq 'en'
+    end
+
+    it "should accept symbols as available languages" do
+      parser.header = 'en-us'
+      expect(parser.compatible_language_from([:"en-HK"])).to eq :"en-HK"
+    end
+
+    it "should accept and ignore wildcards" do
+      parser.header = 'en-US,en,*'
+      expect(parser.compatible_language_from([:"en-US"])).to eq :"en-US"
+    end
+
+    it "should sanitize available language names" do
+      expect(parser.sanitize_available_locales(%w{en_UK-x3 en-US-x1 ja_JP-x2 pt-BR-x5 es-419-x4})).to eq ["en-UK", "en-US", "ja-JP", "pt-BR", "es-419"]
+    end
+
+    it "should accept available language names as symbols and return them as strings" do
+      expect(parser.sanitize_available_locales([:en, :"en-US", :ca, :"ca-ES"])).to eq ["en", "en-US", "ca", "ca-ES"]
+    end
+
+    it "should find most compatible language from user preferred" do
+      parser.header = 'ja,en-gb,en-us,fr-fr'
+      expect(parser.language_region_compatible_from(%w{en-UK en-US ja-JP})).to eq "ja-JP"
+    end
+
+  end

--- a/spec/turnout/i18n/internationalization_spec.rb
+++ b/spec/turnout/i18n/internationalization_spec.rb
@@ -1,0 +1,391 @@
+require 'spec_helper'
+
+describe Turnout::Internationalization do
+
+  module FakeHelper
+    def fake_helper_method
+    end
+  end
+
+  module FakeHelperClass
+  end
+
+  def expanded(path)
+    result = []
+    if File.directory?(path)
+      result.concat(Dir.glob(File.join(path, '**', '**')).map { |file| file }.sort)
+    else
+      result << path
+    end
+    result.uniq!
+    result
+  end
+
+  # Returns all expanded paths but only if they exist in the filesystem.
+  def existent(path)
+    expanded(path).select { |f| File.exist?(f) }
+  end
+
+  let(:locales_dir) { File.expand_path("../../../locales", __FILE__) }
+  let(:en_locale) { File.join(locales_dir, 'en.yml') }
+  let(:de_locale) { File.join(locales_dir, 'de.yml') }
+  let(:fake_paths) {[en_locale, de_locale] }
+
+
+  let(:env) { {'HTTP_ACCEPT_LANGUAGE' => 'en-us' } }
+  let(:subject) {  Turnout::Internationalization }
+  let(:helpers) { [FakeHelper, FakeHelperClass, nil, 0, false, true, '']  }
+
+  it 'should not have an env' do
+    expect(subject.env).to eq(nil)
+  end
+
+  describe '#initialize_i18n' do
+
+    it 'initializes the i18n ' do
+      Turnout.config.i18n.enabled = true
+      expect(subject).to receive(:setup_i18n_config).with(no_args).and_return(true)
+      subject.initialize_i18n(env)
+      expect(subject.env).to eq(env)
+    end
+  end
+
+  describe '#i18n_config' do
+    it 'sets the i18n config variable' do
+      subject.i18n_config
+      expect(subject.instance_variable_get('@i18n_config')).to eq(Turnout.config.i18n)
+    end
+
+    it 'sets the i18n config variable from a Hash' do
+      original = Turnout.config.i18n
+      Turnout.config.i18n = {key: :value }
+      expect(Turnout::InheritableOptions).to receive(:new).with(Turnout.config.i18n)
+      subject.i18n_config
+      Turnout.config.i18n = original
+    end
+  end
+
+  describe '#turnout_page' do
+    it 'sets the turnout page' do
+      subject.turnout_page
+      expect(subject.instance_variable_get('@turnout_page')).to eq(Turnout.config.default_maintenance_page)
+    end
+  end
+
+  describe '#http_accept_language' do
+    it 'sets the http_accept_language' do
+      subject.env = nil
+      expect(Turnout::AcceptLanguageParser).to receive(:new).with(nil)
+      subject.http_accept_language
+    end
+
+    it 'sets the http_accept_language and instantiates the parser' do
+      subject.env = env
+      expect(Turnout::AcceptLanguageParser).to receive(:new).with(env['HTTP_ACCEPT_LANGUAGE'])
+      subject.http_accept_language
+    end
+
+    it 'sets the http_accept_language' do
+      subject.env = env
+      subject.http_accept_language
+      expect(subject.instance_variable_get('@http_accept_language').kind_of?(Turnout::AcceptLanguageParser)).to eq(true)
+    end
+
+  end
+
+  describe '#setup_additional_helpers' do
+
+    it 'gets the helpers from config' do
+      expect(subject.i18n_config).to receive(:delete).with(:additional_helpers).and_return([])
+      subject.setup_additional_helpers
+    end
+
+    it 'includes additional helpers' do
+      original = Turnout.config.i18n
+      Turnout.config.i18n.additional_helpers = helpers
+      helpers.each do |helper|
+        expected =  helper.is_a?(Module) ? 'to' : 'to_not'
+        expect(subject.turnout_page).send(expected, receive(:send).with(:include, helper))
+      end
+      subject.setup_additional_helpers
+      Turnout.config.i18n = original
+    end
+  end
+
+  describe '#setup_i18n_config' do
+
+    before(:each) do
+      allow(subject).to receive(:setup_additional_helpers).with(no_args).and_return(true)
+      allow(subject.i18n_config).to receive(:delete).with(:enforce_available_locales).and_return(false)
+      allow(subject.i18n_config).to receive(:delete).with(:fallbacks).and_return([])
+      allow(subject.i18n_config).to receive(:except).with(:enabled, :use_language_header).and_call_original
+    end
+
+    context '#enforce_available_locales' do
+      it 'sets by default enforce to false' do
+        expect(subject.i18n_config).to receive(:delete).with(:fallbacks).and_return([])
+        expect(I18n).to receive(:enforce_available_locales=).with(false).at_least(:once)
+        subject.setup_i18n_config
+      end
+
+      it 'enforces the i18n locales if needed from config' do
+        I18n.enforce_available_locales = false
+        allow(subject.i18n_config).to receive(:delete).with(:enforce_available_locales).and_return(true)
+        subject.setup_i18n_config
+        expect(I18n.enforce_available_locales).to eq(true)
+      end
+
+      it 'enforces the i18n locales if needed if config returns nil and I18n was configured directly' do
+        I18n.enforce_available_locales = true
+        allow(subject.i18n_config).to receive(:delete).with(:enforce_available_locales).and_return(nil)
+        subject.setup_i18n_config
+        expect(I18n.enforce_available_locales).to eq(true)
+        I18n.enforce_available_locales = false
+      end
+    end
+
+
+    context '#railties_load_path' do
+      let(:fake_load_path) { double }
+
+
+
+      before(:each) do
+        locales_dir
+        allow(fake_load_path).to receive(:+).and_return(true)
+        allow(fake_load_path).to receive(:flatten).and_return([])
+      end
+
+
+      it 'makes sure that unshift and flatten are happening' do
+        original = Turnout.config.i18n
+        Turnout.config.i18n.railties_load_path = [locales_dir]
+        expect(I18n).to receive(:load_path).and_return(fake_load_path).at_least(:once)
+        expect(fake_load_path).to receive(:unshift).with(*[locales_dir].map { |file| existent(file) }.flatten).and_return([])
+        subject.setup_i18n_config
+        Turnout.config.i18n = original
+      end
+
+      it 'sets the load path from globbed paths' do
+        I18n.load_path = []
+        Turnout.config.i18n.railties_load_path = [locales_dir]
+        subject.setup_i18n_config
+        expect(I18n.load_path).to eq([de_locale, en_locale])
+      end
+
+      it 'sets the load path from single paths' do
+        I18n.load_path = []
+        Turnout.config.i18n.railties_load_path = [de_locale, en_locale]
+        subject.setup_i18n_config
+        expect(I18n.load_path).to eq([de_locale, en_locale])
+      end
+    end
+    context '#load_path' do
+      it 'add to the load path from array' do
+        I18n.load_path = []
+        Turnout.config.i18n.railties_load_path = []
+        Turnout.config.i18n.load_path = fake_paths
+        subject.setup_i18n_config
+        expect(I18n.load_path).to eq(fake_paths)
+        Turnout.config.i18n.load_path = []
+      end
+    end
+
+    context 'send dynamic methods to I18n' do
+      it 'add to the load path from array' do
+        original = Turnout.config.i18n
+        Turnout.config.i18n = { key1: :value1,  key2: :value2, enabled: true }
+        Turnout.config.i18n.select{|key, value| ![:enabled].include?(key) }.each do |key, value|
+          expect(I18n).to receive(:send).with("#{key}=", value)
+        end
+        subject.setup_i18n_config
+        Turnout.config.i18n = original
+      end
+    end
+
+    context 'init_fallbacks' do
+      let(:fake_fallbacks) {[double]}
+      before(:each) do
+        allow(subject.i18n_config).to receive(:delete).with(:fallbacks).and_return(fake_fallbacks)
+      end
+
+      it 'inits the fallbacks' do
+        expect(subject).to receive(:init_fallbacks).with(fake_fallbacks)
+        subject.setup_i18n_config
+      end
+    end
+
+    context 'validate_fallbacks' do
+      let(:fake_fallbacks) {[double]}
+      before(:each) do
+        allow(subject.i18n_config).to receive(:delete).with(:fallbacks).and_return(fake_fallbacks)
+      end
+
+      it 'inits the fallbacks' do
+        expect(subject).to receive(:validate_fallbacks).with(fake_fallbacks)
+        subject.setup_i18n_config
+      end
+    end
+
+    context 'load_translations' do
+      let(:fake_backend) {double}
+      before(:each) do
+        allow(I18n).to receive(:backend).and_return(fake_backend)
+      end
+
+      it 'inits the fallbacks' do
+        expect(fake_backend).to receive(:load_translations).with(no_args)
+        subject.setup_i18n_config
+      end
+    end
+
+    context '#use_language_header' do
+      let(:fake_parser) {double}
+
+      context "config true" do
+        before(:each) do
+          allow(subject.i18n_config).to receive(:use_language_header).and_return(true)
+        end
+
+        it 'checks proper method calls' do
+          expect(subject).to receive(:http_accept_language).with(no_args).and_return(fake_parser)
+          expect(fake_parser).to receive(:compatible_language_from).with(I18n.available_locales).and_return("de")
+          subject.setup_i18n_config
+          expect(I18n.locale).to eq(:de)
+        end
+
+        it 'calls original' do
+          expect(I18n.available_locales).to eq([:en])
+          subject.setup_i18n_config
+          expect(I18n.locale).to eq(:en)
+        end
+
+        it 'calls original using default' do
+          I18n.available_locales = []
+          subject.setup_i18n_config
+          expect(I18n.locale).to eq(:en)
+        end
+      end
+
+      context "config false" do
+        before(:each) do
+          allow(subject.i18n_config).to receive(:use_language_header).and_return(false)
+        end
+
+        it 'calls original using default' do
+          expected = 'fake'
+          allow(I18n).to receive(:default_locale).and_return(expected)
+          subject.setup_i18n_config
+          expect(I18n.locale).to eq(expected.to_sym)
+        end
+
+      end
+    end
+
+  end
+
+
+  describe '#array_wrap' do
+    it 'returns []' do
+      result = subject.array_wrap(nil)
+      expect(result).to eq([])
+    end
+
+    it 'returns array' do
+      array = ['a', 'b', 'c']
+      result = subject.array_wrap(array)
+      expect(result).to eq(array)
+    end
+
+    it 'returns array from string' do
+      string = "something"
+      result = subject.array_wrap(string)
+      expect(result).to eq([string])
+    end
+
+    it 'returns array from hash' do
+      hash = {key: :value }
+      result = subject.array_wrap(hash)
+      expect(result).to eq([hash])
+    end
+
+    it 'use to_ary' do
+      expected = "something"
+      fake = double(to_ary: expected)
+      result = subject.array_wrap(fake)
+      expect(result).to eq(fake.to_ary)
+    end
+  end
+
+  describe '#include_fallbacks_module' do
+
+    it 'use to_ary' do
+      expect(I18n.backend.class).to receive(:include).with(I18n::Backend::Fallbacks)
+      subject.include_fallbacks_module
+    end
+  end
+
+  describe '#init_fallbacks' do
+    let(:fake_fallback) { double }
+    let(:fake_fallbacks) {[fake_fallback]}
+
+    it 'includes the default fallback' do
+      expect(subject).to receive(:include_fallbacks_module).with(no_args).and_call_original
+      subject.init_fallbacks(fake_fallback)
+    end
+
+    it 'wraps fallbacks if array' do
+      expect(subject).to receive(:array_wrap).with(fake_fallbacks).and_call_original
+      expect(I18n::Locale::Fallbacks).to receive(:new).with(fake_fallback).and_call_original
+      subject.init_fallbacks(fake_fallbacks)
+    end
+
+    it 'wraps fallbacks if hash' do
+      hash = {key: :value}
+      expect(subject).to receive(:array_wrap).with(hash).and_call_original
+      expect(I18n::Locale::Fallbacks).to receive(:new).with(hash).and_call_original
+      subject.init_fallbacks(hash)
+    end
+
+    it 'uses ordered options' do
+      hash = Turnout::OrderedOptions.new({ map: :value })
+      expected = [*(hash[:defaults] || []) << hash[:map]].compact
+      expect(I18n::Locale::Fallbacks).to receive(:new).with(*expected).and_call_original
+      subject.init_fallbacks(hash)
+      expect(I18n.fallbacks.defaults).to eq(expected)
+    end
+  end
+
+  describe '#validate_fallbacks' do
+    let(:fake_fallback) { double }
+    let(:fake_fallbacks) {[fake_fallback]}
+
+    it 'validates array' do
+      result = subject.validate_fallbacks(fake_fallbacks)
+      expect(result).to eq(true)
+    end
+
+    it 'validates hash' do
+      hash = {key: :value}
+      result = subject.validate_fallbacks(hash)
+      expect(result).to eq(true)
+    end
+
+    it 'validates trueclass' do
+      result= subject.validate_fallbacks(true)
+      expect(result).to eq(true)
+    end
+
+    it 'uses ordered options' do
+      hash = Turnout::OrderedOptions.new({ map: :value })
+      expect(hash).to receive(:empty?).and_call_original
+      subject.validate_fallbacks(hash)
+    end
+
+    it 'raises error if unknown' do
+      data = nil
+      expect { subject.validate_fallbacks(data) }.to raise_error(RuntimeError, "Unexpected fallback type #{data.inspect}")
+    end
+  end
+
+end

--- a/spec/turnout/ordered_options_spec.rb
+++ b/spec/turnout/ordered_options_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+describe Turnout::OrderedOptions do
+  it 'tests usages' do
+    a = Turnout::OrderedOptions.new
+
+    expect(a[:not_set]).to be_nil
+
+    a[:allow_concurrency] = true
+    expect(a.size).to eq(1)
+    expect(a[:allow_concurrency]).to be_truthy
+
+    a[:allow_concurrency] = false
+    expect(a.size).to eq(1)
+    expect(a[:allow_concurrency]).to be_falsy
+
+    a["else_where"] = 56
+    expect(a.size).to eq(2)
+    expect(a[:else_where]).to eq(56)
+  end
+
+  it 'tests looping' do
+    a = Turnout::OrderedOptions.new
+
+    a[:allow_concurrency] = true
+    a["else_where"] = 56
+
+    test = [[:allow_concurrency, true], [:else_where, 56]]
+
+    a.each_with_index do |(key, value), index|
+      expect(test[index].first).to eq(key)
+      expect(test[index].last).to eq(value)
+    end
+  end
+
+  it 'tests method access' do
+    a = Turnout::OrderedOptions.new
+    expect(a.not_set).to eq(nil)
+
+    a.allow_concurrency = true
+    expect(a.size).to eq(1)
+    expect(a.allow_concurrency).to eq(true)
+
+    a.allow_concurrency = false
+    expect(a.size).to eq(1)
+    expect(a.allow_concurrency).to eq(false)
+
+    a.else_where = 56
+    expect(a.size).to eq(2)
+    expect(a.else_where).to eq(56)
+  end
+  it 'tests inheritable_options_continues_lookup_in_parent' do
+    parent = Turnout::OrderedOptions.new
+    parent[:foo] = true
+
+    child = Turnout::InheritableOptions.new(parent)
+    expect(child.foo).to eq(true)
+  end
+
+  it 'tests inheritable_options_can_override_parent' do
+    parent = Turnout::OrderedOptions.new
+    parent[:foo] = true
+
+    child = Turnout::InheritableOptions.new(parent)
+    child[:foo] = :baz
+    expect(child.foo).to eq(:baz)
+  end
+
+  it 'tests inheritable_options_inheritable_copy' do
+    original = Turnout::InheritableOptions.new
+    copy     = original.inheritable_copy
+
+    expect(copy.kind_of?(original.class)).to be_truthy
+    expect(copy.object_id).to_not eq(original.object_id)
+  end
+
+  it 'tests inheritable_options_inheritable_copy from hash' do
+    parent = {foo: true }
+    child = Turnout::InheritableOptions.new(parent)
+    expect(child.foo).to eq(true)
+  end
+
+
+  it 'tests introspection' do
+    a = Turnout::OrderedOptions.new
+    expect(a.respond_to?(:blah)).to be_truthy
+    expect(a.respond_to?(:blah=)).to be_truthy
+    expect(a.method(:blah=).call(42)).to eq(42)
+    expect(a.method(:blah).call).to eq(42)
+  end
+
+  it 'tests test_raises_with_bang' do
+    a = Turnout::OrderedOptions.new
+    a[:foo] = :bar
+    expect(a.respond_to?(:foo)).to be_truthy
+    expect { a.foo! }.to_not raise_error
+    expect(a.foo).to eq(a.foo!)
+
+    expect {
+      a.foo = nil
+      a.foo!
+    }.to raise_error(RuntimeError)
+    expect { a.non_existing_key! }.to raise_error(KeyError)
+  end
+
+
+  it 'tests test_raises_with_bang' do
+    hash = {key: :value}
+    fake =  double(to_hash: hash)
+    a = Turnout::OrderedOptions.new(fake) do |key, value|
+      hash[key]
+    end
+    expect(a).to eq({:key=>:value})
+  end
+end

--- a/turnout.gemspec
+++ b/turnout.gemspec
@@ -21,7 +21,11 @@ spec = Gem::Specification.new do |s|
     s.add_dependency('rack', '~> 1.3')
   end
   s.add_dependency('rack-accept', '~> 0.4')
+  s.add_dependency('i18n', '~> 0.7')
   s.add_development_dependency('rack-test', '~> 0.6')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.0')
+
+  s.add_development_dependency('simplecov', '~> 0.10', '>= 0.10')
+  s.add_development_dependency('simplecov-summary', '~> 0.0.4', '>= 0.0.4')
 end


### PR DESCRIPTION
I added support for I18n internationalization as discussed here: https://github.com/biola/turnout/pull/35 . This should fix this issue https://github.com/biola/turnout/issues/9 

This allows also to inject into the maintenance page additional helpers needed for internationalization or using sprockets (if needed) . Although they will have to add those gems themselves to their Gemfile. 

E.g configuration for Rack  (Or Rails) :  

```ruby 
Turnout.configure do |config|
  config.i18n.load_path = Dir[File.join(config.app_root, 'config', 'locales', '*.yml')]
  config.i18n.additional_helpers = [MyAwesomeModule]
end
```

The additional helpers was added so that depending on preferences and framework, each can add their one modules for handling either I18n translations or use sprockets helpers for rendering css files and js files. 

Let me know what you think. Thank you very much. 

Maybe could be simplified even more. Let me know if you have suggestions 