### PR TITLE
Support rack2.0

### DIFF
--- a/turnout.gemspec
+++ b/turnout.gemspec
@@ -15,7 +15,11 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/biola/turnout'
   s.license = 'MIT'
   s.add_dependency('tilt','>= 1.4', '< 3')
-  s.add_dependency('rack', '~> 1.3')
+  if RUBY_VERSION > "2.2.2"
+    s.add_dependency('rack', '>= 1.3', '< 3')
+  else
+    s.add_dependency('rack', '~> 1.3')
+  end
   s.add_dependency('rack-accept', '~> 0.4')
   s.add_development_dependency('rack-test', '~> 0.6')
   s.add_development_dependency('rspec', '~> 3.0')


### PR DESCRIPTION
I want to use turnout on Rails 5.0
I think it's okay beacause pass the test.
Pointed it me and if there is a problem. I will fix it.