### PR TITLE
Fix MRI warnings

### DIFF
--- a/lib/turnout/maintenance_file.rb
+++ b/lib/turnout/maintenance_file.rb
@@ -20,7 +20,7 @@ module Turnout
     end
 
     def exists?
-      File.exists? path
+      File.exist? path
     end
 
     def to_h
@@ -58,7 +58,7 @@ module Turnout
 
     # Find the first MaintenanceFile that exists
     def self.find
-      path = named_paths.values.find { |path| File.exists? path }
+      path = named_paths.values.find { |path| File.exist? path }
       self.new(path) if path
     end
 

--- a/lib/turnout/maintenance_file.rb
+++ b/lib/turnout/maintenance_file.rb
@@ -6,7 +6,7 @@ module Turnout
     attr_reader :path
 
     SETTINGS = [:reason, :allowed_paths, :allowed_ips, :response_code, :retry_after]
-    attr_reader *SETTINGS
+    attr_reader(*SETTINGS)
 
     def initialize(path)
       @path = path

--- a/lib/turnout/maintenance_file.rb
+++ b/lib/turnout/maintenance_file.rb
@@ -58,7 +58,7 @@ module Turnout
 
     # Find the first MaintenanceFile that exists
     def self.find
-      path = named_paths.values.find { |path| File.exist? path }
+      path = named_paths.values.find { |p| File.exist? p }
       self.new(path) if path
     end
 

--- a/lib/turnout/maintenance_page/base.rb
+++ b/lib/turnout/maintenance_page/base.rb
@@ -59,7 +59,7 @@ module Turnout
       end
 
       def path
-        if File.exists? custom_path
+        if File.exist? custom_path
           custom_path
         else
           default_path

--- a/lib/turnout/maintenance_page/base.rb
+++ b/lib/turnout/maintenance_page/base.rb
@@ -51,7 +51,7 @@ module Turnout
       end
 
       def content
-         file_content.gsub /{{\s?reason\s?}}/, reason
+         file_content.gsub(/{{\s?reason\s?}}/, reason)
       end
 
       def file_content


### PR DESCRIPTION
In my application, I can find some warnings form turnout if ruby is executed with `-W` option.
This change fixes the warnings.


My environment
-------

```bash
$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
```