### PR TITLE
updated i18n

### DIFF
--- a/turnout.gemspec
+++ b/turnout.gemspec
@@ -14,10 +14,10 @@ spec = Gem::Specification.new do |s|
   s.email = 'adam@codenoble.com'
   s.homepage = 'https://github.com/biola/turnout'
   s.license = 'MIT'
-  s.add_dependency('tilt','>= 1.4', '< 3')
+  s.add_dependency('tilt', '>= 1.4', '< 3')
   s.add_dependency('rack', '>= 1.3', '< 3')
   s.add_dependency('rack-accept', '~> 0.4')
-  s.add_dependency('i18n', '~> 0.7')
+  s.add_dependency('i18n', '>= 0.7')
   s.add_development_dependency('rack-test', '~> 0.6')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rspec-its', '~> 1.0')


### PR DESCRIPTION
We're working on updating one of our apps to Rails 5, but Faker and Turnout conflict over gem i18n.  Updated gem to fix conflict.