### PR TITLE
Adding the ability to skip middleware init via configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Turnout can be configured in two different ways:
 
     ```ruby
     Turnout.configure do |config|
+      config.skip_middleware = true
       config.app_root = '/some/path'
       config.named_maintenance_file_paths = {app: 'tmp/app.yml', server: '/tmp/server.yml'}
       config.maintenance_pages_path = 'app/views/maintenance'

--- a/lib/turnout/configuration.rb
+++ b/lib/turnout/configuration.rb
@@ -1,7 +1,7 @@
 require_relative './ordered_options'
 module Turnout
   class Configuration
-    SETTINGS = [:app_root, :named_maintenance_file_paths,
+    SETTINGS = [:skip_middleware, :app_root, :named_maintenance_file_paths,
       :maintenance_pages_path, :default_maintenance_page, :default_reason,
       :default_allowed_paths, :default_response_code, :default_retry_after, :i18n]
 
@@ -10,6 +10,7 @@ module Turnout
     end
 
     def initialize
+      @skip_middleware = false
       @app_root = '.'
       @named_maintenance_file_paths = {default: app_root.join('tmp', 'maintenance.yml').to_s}
       @maintenance_pages_path = app_root.join('public').to_s

--- a/lib/turnout/engine.rb
+++ b/lib/turnout/engine.rb
@@ -7,7 +7,9 @@ if defined? Rails::Engine
   module Turnout
     class Engine < Rails::Engine
       initializer 'turnout.add_to_middleware_stack' do |app|
-        app.config.middleware.use Rack::Turnout
+        unless Turnout.config.skip_middleware
+          app.config.middleware.use(Rack::Turnout)
+        end
       end
     end
   end


### PR DESCRIPTION
We need to be able to load Turnout before Rack::CAS