### PR TITLE
Allow for default_allowed_ips.

### DIFF
--- a/lib/turnout/configuration.rb
+++ b/lib/turnout/configuration.rb
@@ -2,7 +2,7 @@ require_relative './ordered_options'
 module Turnout
   class Configuration
     SETTINGS = [:app_root, :named_maintenance_file_paths,
-      :maintenance_pages_path, :default_maintenance_page, :default_reason,
+      :maintenance_pages_path, :default_maintenance_page, :default_reason, :default_allowed_ips,
       :default_allowed_paths, :default_response_code, :default_retry_after, :i18n]
 
     SETTINGS.each do |setting|
@@ -16,6 +16,7 @@ module Turnout
       @default_maintenance_page = Turnout::MaintenancePage::HTML
       @default_reason = "The site is temporarily down for maintenance.\nPlease check back soon."
       @default_allowed_paths = []
+      @default_allowed_ips = []
       @default_response_code = 503
       @default_retry_after = 7200 # 2 hours by default
       @i18n = Turnout::OrderedOptions.new

--- a/lib/turnout/maintenance_file.rb
+++ b/lib/turnout/maintenance_file.rb
@@ -12,7 +12,7 @@ module Turnout
       @path = path
       @reason = Turnout.config.default_reason
       @allowed_paths = Turnout.config.default_allowed_paths
-      @allowed_ips = []
+      @allowed_ips = Turnout.config.default_allowed_ips
       @response_code = Turnout.config.default_response_code
       @retry_after = Turnout.config.default_retry_after
 


### PR DESCRIPTION
As for other options, allow the user to have default allowed ips in the initializer.