### PR TITLE
Use rails public/maintenance.html

### DIFF
--- a/lib/turnout/maintenance_page/base.rb
+++ b/lib/turnout/maintenance_page/base.rb
@@ -66,10 +66,17 @@ module Turnout
         end
       end
 
-      def default_path
-        File.expand_path("../../../../public/#{filename}", __FILE__)
+      def rails_public_path
+        File.join(Rails.root, 'public', filename) if defined?(Rails)
       end
 
+      def default_path
+        if defined?(Rails) && File.exist?(rails_public_path)
+          rails_public_path
+        else
+          File.expand_path("../../../../public/#{filename}", __FILE__)
+        end
+      end
 
       def filename
         "maintenance.#{extension}"


### PR DESCRIPTION
Hey there!

This gem is great if you just need a quick maintenance mode

But when used in a rails app, it's not correctly rendering the application's public/maintenance.html page.

This fixes #57 

With this change, the rails application's public/maintenance.html will be used when present.

Thanks and have a kickass day.

